### PR TITLE
Fix ORM usage

### DIFF
--- a/api/database/db.py
+++ b/api/database/db.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sqlmodel import SQLModel, create_engine, Session, select
 
 from models.Message import Message
@@ -32,13 +34,14 @@ class Database:
                 session.add(new_user)
                 session.commit()
                 print(f"Created new user with id {new_user.id}")
+
                 return new_user
 
         except Exception as e:
             print(f"Failed to create new user: {e}")
             raise Exception("Failed to nwe create user")
 
-    def update_user(self, user_id: int, user: User) -> User | None:
+    def update_user(self, user_id: int, user: User) -> Optional[User]:
 
         try:
             with Session(self._engine) as session:
@@ -50,6 +53,7 @@ class Database:
                 existing.name = user.name
                 existing.email = user.email
                 session.commit()
+                print(f"Updated user with id {existing.id}")
 
                 return existing
 
@@ -77,6 +81,7 @@ class Database:
             with Session(self._engine) as session:
                 session.add(new_message)
                 session.commit()
+                print(f"Created new message with id {new_message.id}")
 
                 return new_message
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI, Depends, HTTPException
 from starlette import status
 
-from models.User import UserCreate, User
-from models.Customer import CustomerCreate, Customer
-from models.Message import MessageCreate, Message
+from models.User import User
+from models.Customer import Customer
+from models.Message import Message
 
 from database.db import Database
 
@@ -13,7 +13,7 @@ app = FastAPI()
 
 
 @app.post("/api/users", status_code=status.HTTP_201_CREATED)
-async def create_user(new_user: UserCreate, db: Database = Depends(Database.get_db)) -> User:
+async def create_user(new_user: User, db: Database = Depends(Database.get_db)) -> User:
     created_user = db.create_user(new_user)
     if created_user is None:
         raise HTTPException(status_code=status.INTERNAL_SERVER_ERROR, detail="User creation failed")
@@ -22,7 +22,7 @@ async def create_user(new_user: UserCreate, db: Database = Depends(Database.get_
 
 
 @app.put("/api/users/{user_id}", status_code=status.HTTP_200_OK)
-async def create_update(user_id: int, user: UserCreate, db: Database = Depends(Database.get_db)) -> User:
+async def create_update(user_id: int, user: User, db: Database = Depends(Database.get_db)) -> User:
     updated_user = db.update_user(user_id, user)
     if updated_user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"User {user_id} not found")
@@ -31,7 +31,7 @@ async def create_update(user_id: int, user: UserCreate, db: Database = Depends(D
 
 
 @app.post("/api/customers", status_code=status.HTTP_201_CREATED)
-async def create_user(new_customer: CustomerCreate, db: Database = Depends(Database.get_db)) -> Customer:
+async def create_user(new_customer: Customer, db: Database = Depends(Database.get_db)) -> Customer:
     created_customer = db.create_customer(new_customer)
     if created_customer is None:
         raise HTTPException(status_code=status.INTERNAL_SERVER_ERROR, detail="Customer creation failed")
@@ -40,7 +40,7 @@ async def create_user(new_customer: CustomerCreate, db: Database = Depends(Datab
 
 
 @app.post("/api/messages", status_code=status.HTTP_201_CREATED)
-async def create_message(new_message: MessageCreate, db: Database = Depends(Database.get_db)) -> Message:
+async def create_message(new_message: Message, db: Database = Depends(Database.get_db)) -> Message:
     message_created = db.create_message(new_message)
     if message_created is None:
         raise HTTPException(status_code=status.INTERNAL_SERVER_ERROR, detail="Message creation failed")

--- a/api/models/Customer.py
+++ b/api/models/Customer.py
@@ -1,17 +1,17 @@
 from datetime import datetime
+from typing import TYPE_CHECKING, Optional
 
-from pydantic import BaseModel
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
+
+if TYPE_CHECKING:
+    from models.User import User
+    from models.Message import Message
 
 
 class Customer(SQLModel, table=True):
-    id : int | None  = Field(default=None, primary_key=True)
+    id : int | None  = Field(default=None, primary_key=True, index=True)
     name: str = Field(nullable=False)
     contact_id: int = Field(foreign_key="user.id")
-    created_at : datetime = Field(nullable=False)
-
-
-class CustomerCreate(BaseModel):
-    name: str
-    contact_id: int
-    created_at: datetime
+    contact: Optional["User"] = Relationship(back_populates="customers")
+    messages: list["Message"] = Relationship(back_populates="customer")
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now())

--- a/api/models/Customer.py
+++ b/api/models/Customer.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 class Customer(SQLModel, table=True):
-    id : int | None  = Field(default=None, primary_key=True, index=True)
+    id : Optional[int]  = Field(default=None, primary_key=True, index=True)
     name: str = Field(nullable=False)
     contact_id: int = Field(foreign_key="user.id")
     contact: Optional["User"] = Relationship(back_populates="customers")

--- a/api/models/Customer.py
+++ b/api/models/Customer.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Optional
 from sqlmodel import SQLModel, Field, Relationship
 
 if TYPE_CHECKING:
-    from models.User import User
-    from models.Message import Message
+    from .User import User
+    from .Message import Message
 
 
 class Customer(SQLModel, table=True):

--- a/api/models/Message.py
+++ b/api/models/Message.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Optional
 from sqlmodel import SQLModel, Field, Relationship
 
 if TYPE_CHECKING:
-    from models.User import User
-    from models.Customer import Customer
+    from .User import User
+    from .Customer import Customer
 
 
 class Message(SQLModel, table=True):

--- a/api/models/Message.py
+++ b/api/models/Message.py
@@ -1,19 +1,18 @@
 from datetime import datetime
+from typing import TYPE_CHECKING, Optional
 
-from pydantic import BaseModel
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
+
+if TYPE_CHECKING:
+    from models.User import User
+    from models.Customer import Customer
 
 
 class Message(SQLModel, table=True):
-    id: int | None  = Field(default=None, primary_key=True)
+    id: Optional[int]  = Field(default=None, primary_key=True, index=True)
     body: str = Field(nullable=False)
-    created_at: datetime = Field(nullable=False)
     customer_id: int = Field(foreign_key="customer.id")
     user_id: int = Field(foreign_key="user.id")
-
-
-class MessageCreate(BaseModel):
-    body: str
-    customer_id: int
-    user_id: int
-    created_at: datetime
+    customer: Optional["Customer"] = Relationship(back_populates="messages")
+    user: Optional["User"] = Relationship(back_populates="messages")
+    created_at: Optional[datetime] = Field(default_factory=lambda: datetime.now())

--- a/api/models/User.py
+++ b/api/models/User.py
@@ -1,13 +1,14 @@
-from pydantic import BaseModel
-from sqlmodel import SQLModel, Field
+from typing import Optional
+
+from sqlmodel import SQLModel, Field, Relationship
+
+from models.Message import Message
+from models.Customer import Customer
 
 
 class User(SQLModel, table=True):
-    id : int | None  = Field(default=None, primary_key=True)
-    name: str = Field(nullable=False)
-    email : str = Field(nullable=False)
-
-
-class UserCreate(BaseModel):
-    name: str
-    email: str
+    id: Optional[int]  = Field(default=None, primary_key=True, index=True)
+    name: str = Field(nullable=False, index=True)
+    email: str = Field(nullable=False)
+    customers: list["Customer"] = Relationship(back_populates="contact")
+    messages: list["Message"] = Relationship(back_populates="user")

--- a/api/models/User.py
+++ b/api/models/User.py
@@ -1,9 +1,10 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlmodel import SQLModel, Field, Relationship
 
-from models.Message import Message
-from models.Customer import Customer
+if TYPE_CHECKING:
+    from .Message import Message
+    from .Customer import Customer
 
 
 class User(SQLModel, table=True):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ requires-python = ">=3.13,<4.0"
 authors = [
     { name = "Ville Kaikkonen", email = "ville.kaikk@gmail.com" }
 ]
-dependencies = ["fastapi[standard]>=0.116.1", "pydantic>=2.11.7", "uvicorn>=0.35.0", "sqlalchemy>=2.0.43", "sqlmodel>=0.0.24"]
+dependencies = ["fastapi[standard]>=0.116.1", "pydantic>=2.11.7", "uvicorn>=0.35.0", "sqlmodel>=0.0.24"]


### PR DESCRIPTION
- Fixed models to be only SQLModels, removed all pure Pydantic BaseModels
- Added functional SQLModel Relations to the models with circular import guards
- Replaced direct uses of SQLAlchemy API with pure SQLModel API usage
- Removed SQLAlchemy from the project's direct dependencies
- Removed created_at timestamps from the required API fields
- Fixed type annotations